### PR TITLE
fix: redo delete-branches start header for better presentation and fix max_idle_days to allow 0

### DIFF
--- a/src/delete_branches/run.py
+++ b/src/delete_branches/run.py
@@ -64,7 +64,7 @@ def check_user_inputs(repo, repo_url, exclude_branch, max_idle_days):
         print("❌ Error: excluded-branch must be a set")
         return False
 
-    if max_idle_days is not None and (not isinstance(max_idle_days, int) or max_idle_days <= 0):
+    if max_idle_days is not None and (not isinstance(max_idle_days, int) or max_idle_days < 0):
         print("❌ Error: max-idle-days must be an integer (0 or more)")
         return False
 
@@ -220,8 +220,10 @@ def main(dry_run, repo_url, exclude_branches, max_idle_days):
         max_idle_days = int(max_idle_days)
 
     console = Console()
-    console.print(f"\n🚀 Starting to Delete GitHub Branches (dry-run: [red]{dry_run}[/red], repo-url: [red]{repo_url}[/red],"
-                  f" exclude-branches: [red]{set_user_exclude_branches}[/red], max-idle-days: [red]{max_idle_days}[/red])\n")
+    console.print(f"\n🚀 Starting to Delete GitHub Branches (\
+                  dry-run: [red]{dry_run}[/red], \
+                  exclude-branches: [red]{set_user_exclude_branches}[/red], \
+                  max-idle-days: [red]{max_idle_days}[/red])\n")
 
     try:
         """setup github repo object"""


### PR DESCRIPTION
<!-- NOTE: this file is managed by terraform -->
<!-- What's the goal of the Pull Request? -->
#### Why's this PR created?

_This PR accomplishes the following...._
- When **delete-branches** starts header using multiple f-string lines, the header is broken down into multiple lines and looks weird.  Instead of using multiple f-string lines, use \ to break the line.

- If a user specifies max_idle_days being 0, which is not an integer, user input check will fail with an error "max-idle-days must be an integer (0 or more)".  Therefore, needs to change it from <=0 to <0.

