### PR TITLE
fix: run header tab on line break

### DIFF
--- a/src/delete_branches/run.py
+++ b/src/delete_branches/run.py
@@ -220,10 +220,8 @@ def main(dry_run, repo_url, exclude_branches, max_idle_days):
         max_idle_days = int(max_idle_days)
 
     console = Console()
-    console.print(f"\n🚀 Starting to Delete GitHub Branches (\
-                  dry-run: [red]{dry_run}[/red], \
-                  exclude-branches: [red]{set_user_exclude_branches}[/red], \
-                  max-idle-days: [red]{max_idle_days}[/red])\n")
+    console.print(f"\n🚀 Starting to Delete GitHub Branches (dry-run: [red]{dry_run}[/red], \
+exclude-branches: [red]{set_user_exclude_branches}[/red], max-idle-days: [red]{max_idle_days}[/red])\n")
 
     try:
         """setup github repo object"""


### PR DESCRIPTION
<!-- NOTE: this file is managed by terraform -->
<!-- Describe the issue -->
#### Issue Summary
_python line break creates tab_
```
🚀 Starting to Delete GitHub Branches (                  dry-run: True,                   exclude-branches: {'test2', 'badges', 'test'},                   max-idle-days: 3)
```

<!-- What's the goal of the Pull Request? -->
#### Why's this PR created?

_This PR removes the tab._
```
🚀 Starting to Delete GitHub Branches (dry-run: True, exclude-branches: {'test2', 'test', 'badges'}, max-idle-days: 3)
```
